### PR TITLE
teachers/ GET (all) and POST route added

### DIFF
--- a/mathapp.apiDocs.yaml
+++ b/mathapp.apiDocs.yaml
@@ -142,7 +142,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/newTest'
+              $ref: '#/components/schemas/newTestAssignment'
       responses:
         '201':
           $ref: '#/components/responses/201Created'
@@ -235,6 +235,42 @@ paths:
                     type: array
                     items: 
                       $ref: '#/components/schemas/student'
+        '400':
+          $ref: '#/components/responses/400Error'
+  /tests:
+    get:
+      summary: Returns a list of tests
+      #operationID: testss.get_all
+      responses:
+        '200':
+          description: Test List
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  teachers:
+                    description: Array of Test Records
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/test'
+        '400':
+          $ref: '#/components/responses/400Error'
+        '404':
+          $ref: '#/components/responses/404Error'
+    post:
+      summary: Creates a new Test record
+      #operationID: test.add_test
+      requestBody:
+        description: Test to add
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/newTest'
+      responses:
+        '201':
+          $ref: '#/components/responses/201Created'
         '400':
           $ref: '#/components/responses/400Error'
   /tests/{testId}:
@@ -719,6 +755,28 @@ components:
         - attemptsAllowed
         - studentId
         - teacherId
+    newTestAssignment:
+      description: Create a new test for students to take
+      type: object
+      properties:
+        practice:
+          type: boolean
+          description: practice (true), assessment (false)
+          default: true
+        baseNumber:
+          type: integer
+          description: Base number of the test
+        operation:
+          type: string
+          description: Operation for the test either +, -, *, /
+          pattern: '[\+\-\/\*]'
+        attemptsAllowed:
+          type: integer
+          description: Number of times available, -1 for always available
+          default: 1
+      required:
+        - category
+        - attemptsAllowed
     newResult:
       description: Create a new result record
       type: object


### PR DESCRIPTION
Schema for POST of test through student truncated to not include
studentId and teacherId since studentId will be in the URL params
and the teacherId is stored in that student record.